### PR TITLE
Add link to governace page

### DIFF
--- a/src/cljs/fi/velotoken/ux/views.cljs
+++ b/src/cljs/fi/velotoken/ux/views.cljs
@@ -234,6 +234,11 @@
       "SolFin Audit"]
      ]
 
+    [:div.white-paper.grid
+     [:a.column {:href "https://snapshot.page/#/velotoken" :target "_velogovernance"}
+      "Governance"]
+     ]
+
     [:div.main-section
 
      [:div.social-sidebar


### PR DESCRIPTION
There was no link to the governance website. This adds a link in the simplest and cleanest way I could think of.

Some things to note:
* Mayby there should be some spacing between The governace div and the whitepaper div?
* I tried to add the governance link to the whitepaper column but I didn't manage to figure out how to modify the css to make it look good. Any hinters here would be appreciated.